### PR TITLE
feat(remita): add smart name parsing with title stripping and firstName/lastName support

### DIFF
--- a/.changeset/shaky-beds-tell.md
+++ b/.changeset/shaky-beds-tell.md
@@ -1,0 +1,5 @@
+---
+"@use-africa-pay/core": patch
+---
+
+feat(remita): add smart name

--- a/README.md
+++ b/README.md
@@ -176,13 +176,15 @@ initializePayment({
   reference: 'RMT_' + Date.now(),
   user: {
     email: 'customer@example.com',
-    name: 'John Doe', // Required for Remita
+    name: 'John Doe', // Or use firstName/lastName directly
   },
   onSuccess: (response) => {
     console.log('Remita RRR:', response.transactionId);
   },
 });
 ```
+
+**Name handling:** Remita requires both `firstName` and `lastName`. You can provide `name` (auto-parsed) or explicit `firstName`/`lastName`. Titles like "Mr.", "Dr.", "Chief" are automatically stripped.
 
 ### Monnify
 

--- a/packages/core/src/adapters/remita.ts
+++ b/packages/core/src/adapters/remita.ts
@@ -1,5 +1,6 @@
-import { AdapterInterface, AdapterConfig, PaymentResponse } from '../types';
-import { loadScript } from '../scriptLoader';
+import { AdapterInterface, AdapterConfig, PaymentResponse } from "../types";
+import { loadScript } from "../scriptLoader";
+import { parseUserName } from "../utils/sanitize";
 
 declare global {
   interface Window {
@@ -12,17 +13,18 @@ export const RemitaAdapter: AdapterInterface = {
     // Default to Test Mode (Demo) if not specified, for safety
     const isTestMode = options.testMode !== false;
     const url = isTestMode
-      ? 'https://remitademo.net/payment/v1/remita-pay-inline.bundle.js'
-      : 'https://login.remita.net/payment/v1/remita-pay-inline.bundle.js';
+      ? "https://remitademo.net/payment/v1/remita-pay-inline.bundle.js"
+      : "https://login.remita.net/payment/v1/remita-pay-inline.bundle.js";
     await loadScript(url);
   },
   initialize: (config: AdapterConfig) => {
     if (!config.merchantId) {
-      throw new Error('Merchant ID is required for Remita');
+      throw new Error("Merchant ID is required for Remita");
     }
     if (!config.serviceTypeId) {
-      throw new Error('Service Type ID is required for Remita');
+      throw new Error("Service Type ID is required for Remita");
     }
+    const { firstName, lastName } = parseUserName(config.user);
 
     const paymentEngine = window.RmPaymentEngine.init({
       key: config.publicKey,
@@ -32,14 +34,14 @@ export const RemitaAdapter: AdapterInterface = {
       currency: config.currency,
       transactionId: config.reference,
       customerId: config.user.email,
-      firstName: config.user.name?.split(' ')[0] || '',
-      lastName: config.user.name?.split(' ').slice(1).join(' ') || '',
+      firstName,
+      lastName,
       email: config.user.email,
-      narration: config.metadata?.description || 'Payment',
+      narration: config.metadata?.description || "Payment",
       onSuccess: (response: any) => {
         const paymentResponse: PaymentResponse = {
-          status: 'success',
-          message: 'Payment completed successfully',
+          status: "success",
+          message: "Payment completed successfully",
           reference: config.reference,
           transactionId: response.transactionId || response.RRR,
           amount: config.amount,
@@ -50,14 +52,14 @@ export const RemitaAdapter: AdapterInterface = {
             name: config.user.name,
             phone: config.user.phonenumber || config.user.phone,
           },
-          provider: 'remita',
+          provider: "remita",
           metadata: config.metadata,
           raw: response,
         };
         config.onSuccess(paymentResponse);
       },
       onError: (response: any) => {
-        console.error('Remita payment error:', response);
+        console.error("Remita payment error:", response);
       },
       onClose: () => {
         config.onClose();

--- a/packages/core/src/adapters/remita.ts
+++ b/packages/core/src/adapters/remita.ts
@@ -1,5 +1,6 @@
-import { AdapterInterface, AdapterConfig, PaymentResponse } from '../types';
-import { loadScript } from '../scriptLoader';
+import { AdapterInterface, AdapterConfig, PaymentResponse } from "../types";
+import { loadScript } from "../scriptLoader";
+import { parseUserName } from "../utils/sanitize";
 
 declare global {
   interface RmPaymentEngine {
@@ -15,17 +16,18 @@ export const RemitaAdapter: AdapterInterface = {
     // Default to Test Mode (Demo) if not specified, for safety
     const isTestMode = options.testMode !== false;
     const url = isTestMode
-      ? 'https://remitademo.net/payment/v1/remita-pay-inline.bundle.js'
-      : 'https://login.remita.net/payment/v1/remita-pay-inline.bundle.js';
+      ? "https://remitademo.net/payment/v1/remita-pay-inline.bundle.js"
+      : "https://login.remita.net/payment/v1/remita-pay-inline.bundle.js";
     await loadScript(url);
   },
   initialize: (config: AdapterConfig) => {
     if (!config.merchantId) {
-      throw new Error('Merchant ID is required for Remita');
+      throw new Error("Merchant ID is required for Remita");
     }
     if (!config.serviceTypeId) {
-      throw new Error('Service Type ID is required for Remita');
+      throw new Error("Service Type ID is required for Remita");
     }
+    const { firstName, lastName } = parseUserName(config.user);
 
     const paymentEngine = window.RmPaymentEngine.init({
       key: config.publicKey,
@@ -35,14 +37,14 @@ export const RemitaAdapter: AdapterInterface = {
       currency: config.currency,
       transactionId: config.reference,
       customerId: config.user.email,
-      firstName: config.user.name?.split(' ')[0] || '',
-      lastName: config.user.name?.split(' ').slice(1).join(' ') || '',
+      firstName,
+      lastName,
       email: config.user.email,
-      narration: config.metadata?.description || 'Payment',
+      narration: config.metadata?.description || "Payment",
       onSuccess: (response: any) => {
         const paymentResponse: PaymentResponse = {
-          status: 'success',
-          message: 'Payment completed successfully',
+          status: "success",
+          message: "Payment completed successfully",
           reference: config.reference,
           transactionId: response.transactionId || response.RRR,
           amount: config.amount,
@@ -53,14 +55,14 @@ export const RemitaAdapter: AdapterInterface = {
             name: config.user.name,
             phone: config.user.phonenumber || config.user.phone,
           },
-          provider: 'remita',
+          provider: "remita",
           metadata: config.metadata,
           raw: response,
         };
         config.onSuccess(paymentResponse);
       },
       onError: (response: any) => {
-        console.error('Remita payment error:', response);
+        console.error("Remita payment error:", response);
       },
       onClose: () => {
         config.onClose();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,10 +1,12 @@
-export type PaymentProvider = 'paystack' | 'flutterwave' | 'monnify' | 'remita';
+export type PaymentProvider = "paystack" | "flutterwave" | "monnify" | "remita";
 
-export type PaymentStatus = 'pending' | 'success' | 'failed' | 'cancelled';
+export type PaymentStatus = "pending" | "success" | "failed" | "cancelled";
 
 export interface UserConfig {
   email: string;
   name?: string;
+  firstName?: string;
+  lastName?: string;
   phonenumber?: string;
   phone?: string;
 }
@@ -12,7 +14,7 @@ export interface UserConfig {
 // Base configuration shared by all providers
 export interface BaseConfig {
   amount: number; // In lowest denomination (kobo/cents)
-  currency: 'NGN' | 'USD' | 'GHS' | 'KES';
+  currency: "NGN" | "USD" | "GHS" | "KES";
   reference: string;
   publicKey: string;
   user: UserConfig;
@@ -27,23 +29,23 @@ export interface BaseConfig {
 
 // Provider-specific configurations
 export interface PaystackConfig extends BaseConfig {
-  provider: 'paystack';
+  provider: "paystack";
   channels?: string[]; // Paystack specific
 }
 
 export interface FlutterwaveConfig extends BaseConfig {
-  provider: 'flutterwave';
+  provider: "flutterwave";
   payment_options?: string; // Flutterwave specific
 }
 
 export interface MonnifyConfig extends BaseConfig {
-  provider: 'monnify';
+  provider: "monnify";
   contractCode: string;
   user: UserConfig & { name: string }; // Name is required for Monnify
 }
 
 export interface RemitaConfig extends BaseConfig {
-  provider: 'remita';
+  provider: "remita";
   merchantId: string;
   serviceTypeId: string;
   user: UserConfig & { name: string }; // Name is required for Remita
@@ -94,14 +96,14 @@ export class PaymentError extends Error {
     public rawError?: any // Keep the original provider response
   ) {
     super(message);
-    this.name = 'PaymentError';
+    this.name = "PaymentError";
   }
 }
 
 export class ValidationError extends PaymentError {
   constructor(message: string, suggestion?: string) {
-    super(message, 'VALIDATION_ERROR', undefined, suggestion);
-    this.name = 'ValidationError';
+    super(message, "VALIDATION_ERROR", undefined, suggestion);
+    this.name = "ValidationError";
   }
 }
 
@@ -109,18 +111,23 @@ export class NetworkError extends PaymentError {
   constructor(message: string, provider?: PaymentProvider) {
     super(
       message,
-      'NETWORK_ERROR',
+      "NETWORK_ERROR",
       provider,
-      'Check your internet connection and try again.'
+      "Check your internet connection and try again."
     );
-    this.name = 'NetworkError';
+    this.name = "NetworkError";
   }
 }
 
 export class ProviderError extends PaymentError {
-  constructor(message: string, provider: PaymentProvider, suggestion?: string, rawError?: any) {
-    super(message, 'PROVIDER_ERROR', provider, suggestion, rawError);
-    this.name = 'ProviderError';
+  constructor(
+    message: string,
+    provider: PaymentProvider,
+    suggestion?: string,
+    rawError?: any
+  ) {
+    super(message, "PROVIDER_ERROR", provider, suggestion, rawError);
+    this.name = "ProviderError";
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,10 +1,12 @@
-export type PaymentProvider = 'paystack' | 'flutterwave' | 'monnify' | 'remita';
+export type PaymentProvider = "paystack" | "flutterwave" | "monnify" | "remita";
 
-export type PaymentStatus = 'pending' | 'success' | 'failed' | 'cancelled';
+export type PaymentStatus = "pending" | "success" | "failed" | "cancelled";
 
 export interface UserConfig {
   email: string;
   name?: string;
+  firstName?: string;
+  lastName?: string;
   phonenumber?: string;
   phone?: string;
 }
@@ -12,7 +14,7 @@ export interface UserConfig {
 // Base configuration shared by all providers
 export interface BaseConfig {
   amount: number; // In lowest denomination (kobo/cents)
-  currency: 'NGN' | 'USD' | 'GHS' | 'KES';
+  currency: "NGN" | "USD" | "GHS" | "KES";
   reference: string;
   publicKey: string;
   user: UserConfig;
@@ -27,23 +29,23 @@ export interface BaseConfig {
 
 // Provider-specific configurations
 export interface PaystackConfig extends BaseConfig {
-  provider: 'paystack';
+  provider: "paystack";
   channels?: string[]; // Paystack specific
 }
 
 export interface FlutterwaveConfig extends BaseConfig {
-  provider: 'flutterwave';
+  provider: "flutterwave";
   payment_options?: string; // Flutterwave specific
 }
 
 export interface MonnifyConfig extends BaseConfig {
-  provider: 'monnify';
+  provider: "monnify";
   contractCode: string;
   user: UserConfig & { name: string }; // Name is required for Monnify
 }
 
 export interface RemitaConfig extends BaseConfig {
-  provider: 'remita';
+  provider: "remita";
   merchantId: string;
   serviceTypeId: string;
   user: UserConfig & { name: string }; // Name is required for Remita
@@ -94,14 +96,14 @@ export class PaymentError extends Error {
     public rawError?: unknown // Keep the original provider response
   ) {
     super(message);
-    this.name = 'PaymentError';
+    this.name = "PaymentError";
   }
 }
 
 export class ValidationError extends PaymentError {
   constructor(message: string, suggestion?: string) {
-    super(message, 'VALIDATION_ERROR', undefined, suggestion);
-    this.name = 'ValidationError';
+    super(message, "VALIDATION_ERROR", undefined, suggestion);
+    this.name = "ValidationError";
   }
 }
 
@@ -109,18 +111,23 @@ export class NetworkError extends PaymentError {
   constructor(message: string, provider?: PaymentProvider) {
     super(
       message,
-      'NETWORK_ERROR',
+      "NETWORK_ERROR",
       provider,
-      'Check your internet connection and try again.'
+      "Check your internet connection and try again."
     );
-    this.name = 'NetworkError';
+    this.name = "NetworkError";
   }
 }
 
 export class ProviderError extends PaymentError {
-  constructor(message: string, provider: PaymentProvider, suggestion?: string, rawError?: unknown) {
-    super(message, 'PROVIDER_ERROR', provider, suggestion, rawError);
-    this.name = 'ProviderError';
+  constructor(
+    message: string,
+    provider: PaymentProvider,
+    suggestion?: string,
+    rawError?: any
+  ) {
+    super(message, "PROVIDER_ERROR", provider, suggestion, rawError);
+    this.name = "ProviderError";
   }
 }
 

--- a/packages/core/src/utils/sanitize.ts
+++ b/packages/core/src/utils/sanitize.ts
@@ -2,19 +2,21 @@
  * Input sanitization utilities to prevent XSS and injection attacks
  */
 
+import { UserConfig, ValidationError } from "../types";
+
 /**
  * Sanitize email address
  */
 export const sanitizeEmail = (email: string): string => {
-  if (!email) return '';
+  if (!email) return "";
 
   // Remove any HTML tags and trim
-  const cleaned = email.replace(/<[^>]*>/g, '').trim();
+  const cleaned = email.replace(/<[^>]*>/g, "").trim();
 
   // Basic email validation
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(cleaned)) {
-    throw new Error('Invalid email format');
+    throw new Error("Invalid email format");
   }
 
   return cleaned.toLowerCase();
@@ -24,14 +26,14 @@ export const sanitizeEmail = (email: string): string => {
  * Sanitize name (remove special characters that could be used for XSS)
  */
 export const sanitizeName = (name: string): string => {
-  if (!name) return '';
+  if (!name) return "";
 
   // Remove HTML tags
-  let cleaned = name.replace(/<[^>]*>/g, '');
+  let cleaned = name.replace(/<[^>]*>/g, "");
 
   // Remove potentially dangerous characters but keep international characters
   // Allow letters, numbers, spaces, hyphens, apostrophes, and dots
-  cleaned = cleaned.replace(/[^\p{L}\p{N}\s\-'.]/gu, '');
+  cleaned = cleaned.replace(/[^\p{L}\p{N}\s\-'.]/gu, "");
 
   return cleaned.trim();
 };
@@ -40,10 +42,10 @@ export const sanitizeName = (name: string): string => {
  * Sanitize phone number
  */
 export const sanitizePhone = (phone: string): string => {
-  if (!phone) return '';
+  if (!phone) return "";
 
   // Remove everything except digits, +, -, (, ), and spaces
-  const cleaned = phone.replace(/[^\d+\-() ]/g, '').trim();
+  const cleaned = phone.replace(/[^\d+\-() ]/g, "").trim();
 
   return cleaned;
 };
@@ -54,14 +56,16 @@ export const sanitizePhone = (phone: string): string => {
  */
 export const sanitizeReference = (reference: string): string => {
   if (!reference) {
-    throw new Error('Transaction reference is required');
+    throw new Error("Transaction reference is required");
   }
 
   // Remove any characters that aren't alphanumeric, hyphen, or underscore
-  const cleaned = reference.replace(/[^a-zA-Z0-9\-_]/g, '');
+  const cleaned = reference.replace(/[^a-zA-Z0-9\-_]/g, "");
 
   if (cleaned.length === 0) {
-    throw new Error('Transaction reference must contain at least one valid character');
+    throw new Error(
+      "Transaction reference must contain at least one valid character"
+    );
   }
 
   return cleaned;
@@ -71,8 +75,10 @@ export const sanitizeReference = (reference: string): string => {
  * Sanitize metadata object
  * Recursively sanitize all string values to prevent XSS
  */
-export const sanitizeMetadata = (metadata: Record<string, any>): Record<string, any> => {
-  if (!metadata || typeof metadata !== 'object') {
+export const sanitizeMetadata = (
+  metadata: Record<string, any>
+): Record<string, any> => {
+  if (!metadata || typeof metadata !== "object") {
     return {};
   }
 
@@ -80,17 +86,17 @@ export const sanitizeMetadata = (metadata: Record<string, any>): Record<string, 
 
   for (const [key, value] of Object.entries(metadata)) {
     // Sanitize key
-    const cleanKey = key.replace(/[^\w\-]/g, '');
+    const cleanKey = key.replace(/[^\w\-]/g, "");
 
-    if (typeof value === 'string') {
+    if (typeof value === "string") {
       // Remove HTML tags and script tags
       sanitized[cleanKey] = value
-        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-        .replace(/<[^>]*>/g, '')
+        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+        .replace(/<[^>]*>/g, "")
         .trim();
-    } else if (typeof value === 'number' || typeof value === 'boolean') {
+    } else if (typeof value === "number" || typeof value === "boolean") {
       sanitized[cleanKey] = value;
-    } else if (typeof value === 'object' && value !== null) {
+    } else if (typeof value === "object" && value !== null) {
       // Recursively sanitize nested objects
       sanitized[cleanKey] = sanitizeMetadata(value);
     }
@@ -104,7 +110,7 @@ export const sanitizeMetadata = (metadata: Record<string, any>): Record<string, 
  * Redact sensitive information from error messages
  */
 export const redactSensitiveData = (message: string): string => {
-  if (!message) return '';
+  if (!message) return "";
 
   // Redact potential API keys (strings that look like keys)
   let redacted = message.replace(/[a-zA-Z0-9]{20,}/g, (match) => {
@@ -116,10 +122,68 @@ export const redactSensitiveData = (message: string): string => {
   });
 
   // Redact email addresses
-  redacted = redacted.replace(/[\w.-]+@[\w.-]+\.\w+/g, '***@***.***');
+  redacted = redacted.replace(/[\w.-]+@[\w.-]+\.\w+/g, "***@***.***");
 
   // Redact phone numbers
-  redacted = redacted.replace(/\+?\d{10,}/g, '***');
+  redacted = redacted.replace(/\+?\d{10,}/g, "***");
 
   return redacted;
 };
+
+export function parseUserName(user: UserConfig): {
+  firstName: string;
+  lastName: string;
+} {
+  // Priority 1: Use explicit firstName/lastName if both are provided
+  // Handles: { firstName: "John", lastName: "Doe" } → { firstName: "John", lastName: "Doe" }
+  if (user.firstName && user.lastName) {
+    return { firstName: user.firstName, lastName: user.lastName };
+  }
+
+  // Common titles/designations to strip
+  const titles = [
+    "mr",
+    "mrs",
+    "ms",
+    "miss",
+    "dr",
+    "prof",
+    "sir",
+    "chief",
+    "engr",
+    "barr",
+    "hon",
+  ];
+
+  // Split the full name into parts by whitespace
+  let nameParts = (user.name || "").trim().split(/\s+/);
+
+  // Validation: Ensure we have at least one name part
+  if (nameParts.length === 0 || !nameParts[0]) {
+    throw new ValidationError("User name is required for Remita");
+  }
+
+  // Remove title/designation if the first part matches a known title
+  // Handles: "Mr. John Smith" → firstPart="mr" → matches → nameParts=["John", "Smith"]
+
+  if (nameParts.length > 1) {
+    const firstPart = nameParts[0].toLowerCase().replace(".", "");
+    if (titles.includes(firstPart)) {
+      nameParts = nameParts.slice(1);
+    }
+  }
+
+  // Handle single-word names by duplicating for both fields
+  // Remita requires both firstName and lastName, so we use the same value for both
+  // Handles: "Madonna" → { firstName: "Madonna", lastName: "Madonna" }
+  if (nameParts.length === 1) {
+    return { firstName: nameParts[0], lastName: nameParts[0] };
+  }
+
+  // Standard case: first part becomes firstName, remaining parts join as lastName
+  // Handles: "John Doe" → { firstName: "John", lastName: "Doe" }
+  return {
+    firstName: nameParts[0],
+    lastName: nameParts.slice(1).join(" "),
+  };
+}


### PR DESCRIPTION
## Summary
- Add explicit `firstName` and `lastName` fields to `UserConfig` interface
- Implement `parseUserName()` utility for intelligent name handling
- Update Remita adapter to use the new name parsing logic

## Changes
- types.ts: Added optional `firstName`/`lastName` to `UserConfig`
- sanitize.ts: New `parseUserName()` function that:
  - Uses explicit `firstName`/`lastName` if both provided
  - Strips common titles (Mr., Mrs., Dr., Chief, Engr, Barr, Hon, etc.)
  - Handles single-word names by using it for both fields
  - Splits full names into firstName and lastName parts
- remita.ts: Replaced inline name splitting with `parseUserName()`
- **README.md**: Updated documentation for name handling
